### PR TITLE
Upgrade to Babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "stage-0", "react"],
+  "plugins": ["transform-runtime"]
+}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
   "license": "MIT",
   "devDependencies": {
     "autoprefixer": "^6.2.2",
-    "babel-core": "^5.8.25",
-    "babel-loader": "^5.3.2",
-    "babel-runtime": "^5.8.25",
+    "babel-core": "^6.3.26",
+    "babel-loader": "^6.2.0",
+    "babel-plugin-transform-runtime": "^6.3.13",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.4",
     "postcss-loader": "^0.8.0",
@@ -25,6 +28,7 @@
     "webpack-hot-middleware": "^2.2.0"
   },
   "dependencies": {
+    "babel-runtime": "^6.3.19",
     "classnames": "^2.1.2",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
     loaders: [
       { test: /\.html$/, loader: "file?name=[name].[ext]" },
       { test: /\.css$/, loader: "style-loader!css-loader?modules&importLoaders=1!postcss-loader" },
-      { test: /\.(js|jsx)$/, exclude: /node_modules/, loaders: ["react-hot","babel-loader?stage=0&optional=runtime"]},
+      { test: /\.(js|jsx)$/, exclude: /node_modules/, loaders: ["react-hot","babel-loader"]},
     ],
   },
   resolve: {


### PR DESCRIPTION
You'd also want babel-runtime in your normal dependencies since the transform makes your code import it.
