### PR TITLE
Css modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   module: {
     loaders: [
       { test: /\.html$/, loader: "file?name=[name].[ext]" },
-      { test: /\.css$/, loader: "style-loader!css-loader?modules&importLoaders=1!postcss-loader" },
+      { test: /\.css$/, loader: "style-loader!css-loader?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader" },
       { test: /\.(js|jsx)$/, exclude: /node_modules/, loaders: ["react-hot","babel-loader"]},
     ],
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,9 +13,26 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.html$/, loader: "file?name=[name].[ext]" },
-      { test: /\.css$/, loader: "style-loader!css-loader?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader" },
-      { test: /\.(js|jsx)$/, exclude: /node_modules/, loaders: ["react-hot","babel-loader"]},
+      {
+        test: /\.html$/,
+        loader: "file?name=[name].[ext]"
+      },
+      {
+        test: /\.css$/,
+        loaders: [
+          "style-loader",
+          "css-loader?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]",
+          "postcss-loader"
+        ]
+      },
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        loaders: [
+          "react-hot",
+          "babel-loader"
+        ]
+      },
     ],
   },
   resolve: {


### PR DESCRIPTION
Set up css-modules sourceMaps & localIdentName for easier debugging.
Also organize webpack loaders to be easier on the eyes.
