### PR TITLE
use DefinePlugin to inject NODE_ENV into webpack build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 
 var rucksack = require('rucksack-css')
+var webpack = require("webpack")
 
 module.exports = {
   context: __dirname + "/client",
@@ -41,6 +42,11 @@ module.exports = {
   postcss: [
     rucksack({
       autoprefixer: true
+    })
+  ],
+  plugins: [
+    new webpack.DefinePlugin({ 
+      'process.env': { NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development') } 
     })
   ]
 }


### PR DESCRIPTION
see https://github.com/rackt/redux/issues/1029 . If you do not inject NODE_ENV, production build will use dev versions of react/redux/potentially other libs , using `DefinePlugin` means when you buld with `NODE_ENV=production` you will remove slow code paths (such as those that do propType validation)
