### PR TITLE
fix path issue in Windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,14 @@
-
-var rucksack = require('rucksack-css')
+var rucksack = require('rucksack-css'),
+  path = require('path')
 
 module.exports = {
-  context: __dirname + "/client",
+  context: path.join(__dirname, "/client"),
   entry: {
     jsx: "./index.jsx",
     html: "./index.html",
   },
   output: {
-    path: __dirname + "/static",
+    path: path.join(__dirname, "/static"),
     filename: "bundle.js",
   },
   module: {


### PR DESCRIPTION
The `webpack.config.js` is not working on Windows platform. And  [Webpack document](https://webpack.github.io/docs/troubleshooting.html) mentioned, the config like `__dirname + "/client"` will cause wrong path in Windows. It should replaced with `path.join(__dirname, "/client")` to avoid problem 
