### PR TITLE
fix webpack path issue on windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = {
     })
   ],
   devServer: {
-    contentBase: "./client",
+    contentBase: './client',
     hot: true
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,16 @@
 var rucksack = require('rucksack-css')
 var webpack = require('webpack')
+var path = path = require('path')
 
 module.exports = {
-  context: __dirname + '/client',
+  context: path.resolve(__dirname, './client'),
   entry: {
     jsx: './index.jsx',
     html: './index.html',
     vendor: ['react']
   },
   output: {
-    path: __dirname + '/static',
+    path: path.resolve(__dirname, './static'),
     filename: 'bundle.js',
   },
   module: {
@@ -49,5 +50,9 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env': { NODE_ENV: JSON.stringify(process.env.NODE_ENV || 'development') }
     })
-  ]
+  ],
+  devServer: {
+    contentBase: "./client",
+    hot: true
+  }
 }


### PR DESCRIPTION
Hi,

Just try to running dev server on Windows. But I found some path errors from webpack. Here's my fix
-  According to  [Webpack document](https://webpack.github.io/docs/troubleshooting.html), the config like `__dirname + "/client"` is leading a wrong path in Windows. It should replaced with something like `path.join(__dirname, "./client")` to avoid problem.
- running web-dev-server on windows seems required the `contentBase` option (otherwise it will listing the directory)

:D
