### PR TITLE
Fix typo in webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 var rucksack = require('rucksack-css')
 var webpack = require('webpack')
-var path = path = require('path')
+var path = require('path')
 
 module.exports = {
   context: path.join(__dirname, './client'),


### PR DESCRIPTION
I believe this `var path = path = require` is just a typo.
