### PR TITLE
Changed from redux-simple-router to renamed react-router-redux

### DIFF
--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -1,5 +1,5 @@
 
-import { routeReducer as routing } from 'redux-simple-router'
+import { routeReducer as routing } from 'react-router-redux'
 import { combineReducers } from 'redux'
 import todos from './todos'
 

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -1,6 +1,6 @@
 
 import { createStore, applyMiddleware } from 'redux'
-import { syncHistory } from 'redux-simple-router'
+import { syncHistory } from 'react-router-redux'
 import { browserHistory } from 'react-router'
 
 import { logger } from '../middleware'

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "react-hot-loader": "^1.3.0",
     "react-redux": "^4.0.6",
     "react-router": "^2.0.0-rc5",
+    "react-router-redux": "^2.1.0",
     "redux": "^3.0.2",
-    "redux-actions": "^0.9.0",
-    "redux-simple-router": "^2.0.4"
+    "redux-actions": "^0.9.0"
   }
 }


### PR DESCRIPTION
redux-simple-router was renamed to react-redux-router, so changed the references. Also, bumped the version from 2.0.4 to 2.1.0.
