### PR TITLE
Add a css loader to import global style from third party components

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,11 +21,17 @@ module.exports = {
       },
       {
         test: /\.css$/,
+        include: /client/,
         loaders: [
           'style-loader',
           'css-loader?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]',
           'postcss-loader'
         ]
+      },
+      {
+        test: /\.css$/,
+        exclude: /client/,
+        loader: 'style!css'
       },
       {
         test: /\.(js|jsx)$/,


### PR DESCRIPTION
An additional loader to manage global style import from third party components. 

Example:
1) I install [MUI](https://www.muicss.com/)
2) I decide to import the dropdown component inside my own component; i import js and css 
3) Webpack parse it as local css
4) MUI components doesn't work.
