### PR TITLE
Reduce boilerplate, use `mapDispatchToProps` obj

### DIFF
--- a/client/containers/App/index.js
+++ b/client/containers/App/index.js
@@ -26,13 +26,7 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    actions: bindActionCreators(TodoActions, dispatch)
-  }
-}
-
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  { actions: TodoActions }
 )(App)


### PR DESCRIPTION
Change based on this https://github.com/reactjs/react-redux/blob/v4.4.0/src/components/connect.js#L38
