### PR TITLE
Express server

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ A boilerplate of things that mostly shouldn't exist.
 - [x] [React Router Redux](https://github.com/reactjs/react-router-redux)
 - [x] [Redux DevTools Extension](https://github.com/zalmoxisus/redux-devtools-extension)
 - [ ] Redux effects
+- [x] [Express](https://github.com/expressjs/express) API Server
 - [x] TodoMVC example
 
 ## Setup
@@ -35,6 +36,13 @@ $ npm start
 ```
 $ npm run build
 ```
+
+## Running in Production
+
+```
+$ npm run start@prod
+```
+It will automatically run `npm run build` and then run `npm start` with `NODE_ENV=production`.
 
 ## Note
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack-dev-server -d --history-api-fallback --hot --inline --progress --colors --port 3000",
-    "build": "NODE_ENV=production webpack --progress --colors"
+    "start": "node server/index.js",
+    "build": "NODE_ENV=production webpack --progress --colors",
+    "serve": "npm run build & NODE_ENV=production npm run start"
   },
   "license": "MIT",
   "devDependencies": {
@@ -17,16 +18,13 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "css-loader": "^0.23.1",
-    "file-loader": "^0.8.5",
-    "postcss-loader": "^0.8.1",
-    "rucksack-css": "^0.8.5",
-    "style-loader": "^0.13.0",
-    "webpack": "^1.12.14",
-    "webpack-dev-server": "^1.14.1",
-    "webpack-hot-middleware": "^2.7.1",
     "babel-runtime": "^6.5.0",
     "classnames": "^2.2.3",
+    "connect-history-api-fallback": "^1.1.0",
+    "css-loader": "^0.23.1",
+    "express": "^4.13.4",
+    "file-loader": "^0.8.5",
+    "postcss-loader": "^0.8.1",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-hot-loader": "^1.3.0",
@@ -34,6 +32,11 @@
     "react-router": "^2.0.0",
     "react-router-redux": "^4.0.0",
     "redux": "^3.3.1",
-    "redux-actions": "^0.9.1"
+    "redux-actions": "^0.9.1",
+    "rucksack-css": "^0.8.5",
+    "style-loader": "^0.13.0",
+    "webpack": "^1.12.14",
+    "webpack-dev-server": "^1.14.1",
+    "webpack-hot-middleware": "^2.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server/index.js",
     "build": "NODE_ENV=production webpack --progress --colors",
-    "serve": "npm run build & NODE_ENV=production npm run start"
+    "start@prod": "npm run build & NODE_ENV=production npm run start"
   },
   "license": "MIT",
   "devDependencies": {

--- a/server/index.js
+++ b/server/index.js
@@ -8,40 +8,36 @@ const SERVER_PORT = 3001
 
 const app = express()
 
+/*
+  Development Env: enable the HotReplacementPugin dynamically
+  Production Env: Set the Server's static path to the webpack build(output) path.
+*/
 if(app.get('env') === 'development'){
-
-  //enable HotReplacementPlugin
   webpackConfig.entry.jsx = [webpackConfig.entry.jsx]
   webpackConfig.entry.jsx.unshift(`webpack-dev-server/client?http://localhost:${CLIENT_PORT}/`, "webpack/hot/dev-server")
   webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin())
-
   const devServer= new WebpackDevServer(webpack(webpackConfig), {
-    contentBase: __dirname + '/../client', //seems doesn't effect
+    contentBase: __dirname + '/../client', 
     hot: true,
     historyApiFallback: true,
-
-    //proxy the server port, so that easy to avoid cross-domain while requesting the APIs
+    //proxy the server port, easy to avoid cross-domain while requesting the APIs
     proxy: {
-      "/api/*": `http://localhost:${SERVER_PORT}`
+      "/api/*": `http://localhost:${SERVER_PORT}`,
+      // "*": `http://localhost:${SERVER_PORT}`
     },
-
-    // webpack-dev-middleware options
     stats: { colors: true },
   }).listen(CLIENT_PORT)
-
 }
 else{
+  // enable history-api-fallback
   app.use(history())
   app.use(express.static(__dirname + '/../static'))
 }
 
-app.get('/test', function (req, res) {
-  res.send('Hello World!')
-});
 app.get('/api/test', function (req, res) {
-  res.send('Hello World!')
+  res.send('The APIs works!')
 });
 
 app.listen(SERVER_PORT, function () {
-  console.log(`Example app listening on port ${SERVER_PORT}!`)
+  console.log(`API Server listening on port ${SERVER_PORT}!`)
 });

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,47 @@
+const express = require('express')
+const webpack = require('webpack')
+const WebpackDevServer = require('webpack-dev-server')
+const webpackConfig = require('../webpack.config.js')
+const history = require('connect-history-api-fallback');
+const CLIENT_PORT = 3000
+const SERVER_PORT = 3001
+
+const app = express()
+
+if(app.get('env') === 'development'){
+
+  //enable HotReplacementPlugin
+  webpackConfig.entry.jsx = [webpackConfig.entry.jsx]
+  webpackConfig.entry.jsx.unshift(`webpack-dev-server/client?http://localhost:${CLIENT_PORT}/`, "webpack/hot/dev-server")
+  webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin())
+
+  const devServer= new WebpackDevServer(webpack(webpackConfig), {
+    contentBase: __dirname + '/../client', //seems doesn't effect
+    hot: true,
+    historyApiFallback: true,
+
+    //proxy the server port, so that easy to avoid cross-domain while requesting the APIs
+    proxy: {
+      "/api/*": `http://localhost:${SERVER_PORT}`
+    },
+
+    // webpack-dev-middleware options
+    stats: { colors: true },
+  }).listen(CLIENT_PORT)
+
+}
+else{
+  app.use(history())
+  app.use(express.static(__dirname + '/../static'))
+}
+
+app.get('/test', function (req, res) {
+  res.send('Hello World!')
+});
+app.get('/api/test', function (req, res) {
+  res.send('Hello World!')
+});
+
+app.listen(SERVER_PORT, function () {
+  console.log(`Example app listening on port ${SERVER_PORT}!`)
+});

--- a/server/index.js
+++ b/server/index.js
@@ -2,7 +2,7 @@ const express = require('express')
 const webpack = require('webpack')
 const WebpackDevServer = require('webpack-dev-server')
 const webpackConfig = require('../webpack.config.js')
-const history = require('connect-history-api-fallback');
+const history = require('connect-history-api-fallback')
 const CLIENT_PORT = 3000
 const SERVER_PORT = 3001
 
@@ -34,10 +34,10 @@ else{
   app.use(express.static(__dirname + '/../static'))
 }
 
-app.get('/api/test', function (req, res) {
+app.get('/api/test', (req, res) => {
   res.send('The APIs works!')
-});
+})
 
-app.listen(SERVER_PORT, function () {
+app.listen(SERVER_PORT, () => {
   console.log(`API Server listening on port ${SERVER_PORT}!`)
-});
+})


### PR DESCRIPTION
hmm, i just implemented a simple example of express api server for my own need. 
the main concept is:
- run the webpack-dev-server in server/index.js, then it will enable/now enable the HotReplacementModule according to the development/production environment.
- the webpack-dev-server enables proxy to the API server, easiest way to avoid cross-domain problem while requesting the API on client side.
- In production env, run simply `npm run start@prod`, it will excute `npm run build & NODE_ENV=production npm run start`, which will build the client's static files and set the server's static path to the webpack build(output) path.

What i haven't done jet:
- Babel polyfill for server side. (but personally i consider it as unnecessary, node itself already had the support for most ES6 features, except the module-loader, destructure.. so running server without polyfill will achieve better performance)
- more clear structure and organisation of server side
