### PR TITLE
Update react-hot-loader to 3.0.0-beta.6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "stage-0", "react"],
-  "plugins": ["transform-runtime"]
+  "plugins": ["react-hot-loader/babel", "transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "classnames": "^2.2.3",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
-    "react-hot-loader": "^1.3.0",
+    "react-hot-loader": "^3.0.0-beta.6",
     "react-redux": "^4.4.0",
     "react-router": "^2.0.0",
     "react-router-redux": "^4.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,6 @@ module.exports = {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
         loaders: [
-          'react-hot',
           'babel-loader'
         ]
       },


### PR DESCRIPTION
This upgrades from a no longer supported version.

See [https://github.com/gaearon/react-hot-loader/issues/417](https://github.com/gaearon/react-hot-loader/issues/417)